### PR TITLE
Fix duplication of pagination bug.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -169,7 +169,8 @@ var MalinkyAjaxPaging = ( function( $ ) {
                                     history.pushState( null, null, mapNextPageUrl );
 
                                     // Find the new navigation and update, active state, next and prev buttons.
-                                    var $mapNewPagination = $( mapResponse ).find( mapPaginationClass );
+                                    // Use first to ensure pages with top and bottom pagination doesn't replace them twice.
+                                    var $mapNewPagination = $( mapResponse ).find( mapPaginationClass ).first();
                                     $( mapPaginationClass ).replaceWith( $mapNewPagination );
                                 }
 


### PR DESCRIPTION
Fixed a bug where pages that used pagination at the top and bottom of
the page and selected page numbered pagination this would get
duplicated when used.
