### PR TITLE
Update main.js

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -56,7 +56,7 @@ var MalinkyAjaxPaging = ( function( $ ) {
                                 },
                     success:    function( response ) {
                                     // Parse HTML first.
-                                    var mapResponse = $.parseHTML( response );
+                                    var mapResponse = $('<container>').append($.parseHTML( response ));
 
                                     // Find the post wrappers.
                                     var $postsWrapperClass = $( mapResponse ).find( mymapPostsWrapperClass );


### PR DESCRIPTION
When the posts-container is a top level element the jquery find-method won't find it. A possible fix would be to load the nodes to a dom-object.